### PR TITLE
Added a limit for the number of shown rows

### DIFF
--- a/connection.schema.json
+++ b/connection.schema.json
@@ -30,8 +30,15 @@
       "minimum": 1,
       "default": 5506,
       "type": "integer"
+    },
+    "maxRows": {
+      "title": "Max rows to show",
+      "minimum": 0,
+      "default": 50,
+      "type":"integer"
     }
   },
+
   "properties": {
     "server": {
       "$ref": "#/definitions/server"
@@ -47,6 +54,9 @@
     },
     "password": {
       "$ref": "#/definitions/password"
+    },
+    "maxRows": {
+      "$ref": "#/definitions/maxRows"
     }
   },
   "required": [

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,7 +1,5 @@
 import { IDriverAlias } from '@sqltools/types';
 
-const { displayName } = require('../package.json');
-
 export const DRIVER_ALIASES: IDriverAlias[] = [
-  { displayName: displayName, value: displayName },
+  { displayName: "SingleStoreDB", value: "SingleStoreDB" },
 ];

--- a/src/ls/queries.ts
+++ b/src/ls/queries.ts
@@ -54,8 +54,7 @@ ORDER BY
 export const fetchRecords: IBaseQueries['fetchRecords'] = queryFactory`
 SELECT *
 FROM ${p => escapeTableName(p.table)}
-LIMIT ${p => p.limit || 50}
-OFFSET ${p => p.offset || 0};
+LIMIT ${p => p.limit || 50};
 `;
 
 export const countRecords: IBaseQueries['countRecords'] = queryFactory`

--- a/ui.schema.json
+++ b/ui.schema.json
@@ -4,7 +4,8 @@
     "port",
     "database",
     "username",
-    "password"
+    "password",
+    "maxRows"
   ],
   "password": {
     "ui:widget": "password"


### PR DESCRIPTION
Previously rows were shown on different pages.
Each page was loaded by a separate query.
As a result, it was possible that one row is shown on several pages. 
Added a limit for the number of shown rows.
Added maximum rows parameter.