### PR TITLE
Fixed bug in statement splitting

### DIFF
--- a/src/ls/parse.test.ts
+++ b/src/ls/parse.test.ts
@@ -92,7 +92,7 @@ describe('query parse', () => {
         
         SELECT * FROM courses;
         SELECT * FROM courses;
-        `)).toEqual([
+        DELIMITER ;`)).toEqual([
             `CREATE TABLE courses(course_code TEXT, section_number INT, number_students INT)`,
             `
         

--- a/src/ls/parse.ts
+++ b/src/ls/parse.ts
@@ -158,7 +158,9 @@ class QueryParser {
     let parsedQueryAfterIndex = query.substring(index);
     if (parsedQueryAfterIndex.toLowerCase().startsWith(delimiterKeyword)) {
       parsedQueryAfterIndex = parsedQueryAfterIndex.substring(delimiterLength)
-      let delimiterSymbol = parsedQueryAfterIndex.substring(0, parsedQueryAfterIndex.search("\\s"));
+      const whiteSpaceIndex = parsedQueryAfterIndex.search("\\s")
+      let delimiterSymbol = whiteSpaceIndex == -1 ? parsedQueryAfterIndex :
+        parsedQueryAfterIndex.substring(0, parsedQueryAfterIndex.search("\\s"));
       const delimiterSymbolEndIndex = index + delimiterLength + delimiterSymbol.length
       delimiterSymbol = delimiterSymbol.trim();
       if (delimiterSymbol != '') {


### PR DESCRIPTION
When the delimiter is a last statement, it was not omitted